### PR TITLE
Reflect deck template on edit page

### DIFF
--- a/src/main/webapp/deck-edit.html
+++ b/src/main/webapp/deck-edit.html
@@ -19,7 +19,10 @@
 	<div id="deck-edit-screen" class="deck-edit-screen">
 		<div class="card-list-area">
 			<div class="holding-area">
-				<span class="title-caption">所持カード</span>
+				<div class="holding-area-header">
+					<span class="title-caption">所持カード</span>
+					<span class="deck-template-select"></span>
+				</div>
 				<div class="holding-card-list">
 				</div>
 			</div>
@@ -74,6 +77,14 @@
 			</div>
 		{{/list}}
 	</script>
+	<script type="text/template" id="deck-template-select-template">
+		<select name="deck-template-select" id="deck-template-select">
+			{{#list}}
+			<option value="{{deckCode}}">{{deckName}}</option>
+			{{/list}}
+		</select>
+		<button id="deck-template-reflect" class="btn deck-template-reflect-btn">テンプレートをコピー</button>
+	</script>
 
 
 
@@ -95,6 +106,8 @@
 	<script type="text/javascript" src="js/dao/deck-dao.js"></script>
 	<script type="text/javascript" src="js/dao/skill-dao.js"></script>
 	<script type="text/javascript" src="js/dao/holding-card-dao.js"></script>
+	<script type="text/javascript" src="js/dao/deck-template-dao.js"></script>
+	<script type="text/javascript" src="js/dao/api-ajax/game-table-api-ajax.js"></script>
 	<script type="text/javascript" src="js/view/detail-area-view.js"></script>
 	<script type="text/javascript" src="js/view/deckedit/deck-edit-view.js"></script>
 	<script type="text/javascript" src="js/view/renderer/card-detail-renderer.js"></script>

--- a/src/main/webapp/js/controller/deckedit/deck-edit-controller.js
+++ b/src/main/webapp/js/controller/deckedit/deck-edit-controller.js
@@ -5,6 +5,7 @@
     this.cardMstDao_ = new CardMstDao();
     this.skillDao_ = new SkillDao();
     this.deckDao_ = new DeckDao();
+    this.deckTemplateDao_ = new DeckTemplateDao();
 
     this.regulation_ = new RegulationChecker();
     this.view_ = new DeckEditView(this.regulation_);
@@ -30,6 +31,7 @@
     this.view_.getElement().on(DeckEditView.EventType.EXIT, this.onExit_.bind(this));
     this.view_.getElement().on(DeckEditView.EventType.ADD_TO_DECK, this.onAdd_.bind(this));
     this.view_.getElement().on(DeckEditView.EventType.REMOVE_FROM_DECK, this.onRemove_.bind(this));
+    this.view_.getElement().on(DeckEditView.EventType.REFLECT_DECK_TEMPLATE, this.onReflectDeckTemplate_.bind(this));
   };
 
   DeckEditController.prototype.onAdd_ = function(e, code) {
@@ -86,7 +88,12 @@
   };
 
   DeckEditController.prototype.reset_ = function() {
+    this.initDeckTemplateSelect_();
     var deckCodes = this.deckDao_.get(this.userId_);
+    this.setDeck_(deckCodes);
+  };
+
+  DeckEditController.prototype.setDeck_ = function(deckCodes) {
     this.deck_ = [];
 
     var cardCount = {};
@@ -135,6 +142,26 @@
       return 99;
     }
     return this.regulation_.sameCard();
+  };
+
+  DeckEditController.prototype.initDeckTemplateSelect_ = function() {
+    this.deckTemplateDao_.getTemplates()
+      .done(function(deckTemplates) {
+        this.view_.redrawTemplateSelect(deckTemplates);
+      }.bind(this))
+      .fail(function(error) {
+        console.error(error);
+      });
+  };
+
+  DeckEditController.prototype.onReflectDeckTemplate_ = function(e, deckCode) {
+    this.deckTemplateDao_.getTemplateCards(deckCode)
+      .done(function(deckCodes) {
+        this.setDeck_(deckCodes);
+      }.bind(this))
+      .fail(function(error) {
+        console.error(error);
+      });
   };
 
 })(jQuery);

--- a/src/main/webapp/js/dao/api-ajax/game-table-api-ajax.js
+++ b/src/main/webapp/js/dao/api-ajax/game-table-api-ajax.js
@@ -1,0 +1,40 @@
+(function($) {
+
+  GameTableApiAjax = function(opt_apiConfig) {
+    this.apiConfig_ = opt_apiConfig || this.resolveApiConfig_();
+    this.baseUrl_ = this.apiConfig_['apiUrl'] + '/api/' + this.apiConfig_['apiVersion'] + '/';
+  };
+
+  GameTableApiAjax.prototype.resolveApiConfig_ = function() {
+    var href = $(location).attr('href');
+    if (href.indexOf('localhost') > -1) {
+      return {
+        'apiUrl': 'http://localhost:8080',
+        'apiVersion': 'v1'
+      }
+    } else {
+      // deployed environment
+      return {
+        'apiUrl': 'https://pokemon-card-server-game-table.herokuapp.com',
+        'apiVersion': 'v1'
+      }
+    }
+  };
+
+  GameTableApiAjax.prototype.get = function(apiPath, parameters) {
+    return $.ajax({
+      'type': 'GET',
+      'url': this.baseUrl_ + apiPath,
+      'data': parameters
+    });
+  };
+
+  GameTableApiAjax.prototype.post = function(apiPath, parameters) {
+    return $.ajax({
+      'type': 'POST',
+      'url': this.baseUrl_ + apiPath,
+      'data': parameters
+    });
+  };
+
+})(jQuery);

--- a/src/main/webapp/js/dao/deck-template-dao.js
+++ b/src/main/webapp/js/dao/deck-template-dao.js
@@ -1,0 +1,15 @@
+(function($) {
+
+  DeckTemplateDao = function() {
+    this.gamaTableApiAjax_ = new GameTableApiAjax();
+  };
+
+  DeckTemplateDao.prototype.getTemplates = function() {
+    return this.gamaTableApiAjax_.get('deck/templates');
+  };
+
+  DeckTemplateDao.prototype.getTemplateCards = function(deckCode) {
+    return this.gamaTableApiAjax_.get('deck/templates/' + deckCode + '/cards');
+  };
+
+})(jQuery);

--- a/src/main/webapp/js/view/deckedit/deck-edit-view.js
+++ b/src/main/webapp/js/view/deckedit/deck-edit-view.js
@@ -10,7 +10,8 @@
       REMOVE_FROM_DECK: 'remove-from-deck',
       SAVE: 'save',
       REVERT: 'revert',
-      EXIT: 'exit'
+      EXIT: 'exit',
+      REFLECT_DECK_TEMPLATE: 'reflect-deck-template'
   };
 
   DeckEditView.prototype.getElement = function(){
@@ -50,6 +51,16 @@
       $errorMessage.hide();
     }
     $count.text(count);
+  };
+
+  DeckEditView.prototype.redrawTemplateSelect = function(deckTemplates) {
+    if (!deckTemplates || deckTemplates.length < 1) {
+      return;
+    }
+    var $view = this.$element_;
+    var holdingTmpl = Hogan.compile($('#deck-template-select-template').text());
+    $view.find('.deck-template-select').html(holdingTmpl.render({'list':deckTemplates}));
+    this.$element_.on('click', '.deck-template-reflect-btn', this.onDeckTemplateReflectClick_.bind(this));
   };
 
   DeckEditView.prototype.enterDocument = function(){
@@ -92,6 +103,11 @@
     }
     var data = $target.attr('data-code');
     this.$element_.trigger(DeckEditView.EventType.REMOVE_FROM_DECK, data);
+  };
+
+  DeckEditView.prototype.onDeckTemplateReflectClick_ = function(e) {
+    var selectedDeckCode = $('#deck-template-select').val();
+    this.$element_.trigger(DeckEditView.EventType.REFLECT_DECK_TEMPLATE, selectedDeckCode);
   };
 
   DeckEditView.prototype.containsBaseMonster_ = function(deck) {


### PR DESCRIPTION
On deck edit page, user can copy deck template provided from server side

![reflect-deck-template](https://cloud.githubusercontent.com/assets/6829495/21690338/2aa9dbfa-d3b7-11e6-913a-f389f6e0ba23.gif)
